### PR TITLE
Clean up warnings and fix parameter order mismatch

### DIFF
--- a/src/AudioFilterTypes.h
+++ b/src/AudioFilterTypes.h
@@ -39,7 +39,7 @@ public:
     *   ctor. Takes the maximum size as argument.
     */
     PreallocatedArray(int maxSize)
-        : elements(maxSize)
+        : elements(size_t (maxSize))
     {
     }
 

--- a/src/ButterworthCreator.h
+++ b/src/ButterworthCreator.h
@@ -248,7 +248,7 @@ public:
             break;
         case bwHiPass:
             if (useQBasedButterworth)
-                QBasedButterworth::createHiLoPass(cascade, true, freq, order, sampleRate, impl);
+                QBasedButterworth::createHiLoPass(cascade, freq, true, order, sampleRate, impl);
             else
                 creator.createHiLoPass(cascade, freq, true, order, sampleRate);
             break;

--- a/src/ParametricCreator.cpp
+++ b/src/ParametricCreator.cpp
@@ -428,7 +428,10 @@ void createBLTStage(BiquadParam& param, double freq, double gain, double Q, Filt
         param.b2 = (A * ((A + 1) + (A - 1)*cos(w0) - 2 * sqrt(A)*alpha)) / a0;
         param.a1 = (2 * ((A - 1) - (A + 1)*cos(w0))) / a0;
         param.a2 = ((A + 1) - (A - 1)*cos(w0) - 2 * sqrt(A)*alpha) / a0;
+    default:
+        break;
     }
+
     param.useCompensation = false;
 }
 

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -12,14 +12,14 @@ namespace Response
 //==============================================================================
 std::vector<float> createLogFreqs(float startFreq, float endFreq, int numPoints)
 {
-    std::vector<float> ret(numPoints);
+    std::vector<float> ret ((size_t) numPoints);
 
     const auto logEndStart = std::log(endFreq / startFreq);
 
     for (int i = 0; i < numPoints; ++i)
     {
         const auto freq = startFreq * std::exp(logEndStart * i / (numPoints - 1.f));
-        ret[i] = freq;
+        ret[size_t (i)] = freq;
     }
 
     return ret;
@@ -194,7 +194,7 @@ void ResponseBase::getResponse(const BiquadParam& params, std::vector<float>& ga
     {
         const auto bin = getBinForFreq(peakFreq);
         const auto gain = AudioFilter::Response::getResponsePoint(params, peakFreq, sampleRate);
-        gains[bin] = static_cast<float> (gain*gain);
+        gains[size_t (bin)] = static_cast<float> (gain*gain);
     }
 }
 
@@ -211,7 +211,7 @@ void ResponseBase::getResponse(const BiquadParamCascade& params, std::vector<flo
     {
         const auto bin = getBinForFreq(peakFreq);
         const auto gain = AudioFilter::Response::getResponsePoint(params, peakFreq, sampleRate);
-        gains[bin] = static_cast<float> (gain*gain);
+        gains[size_t (bin)] = static_cast<float> (gain*gain);
     }
 }
 


### PR DESCRIPTION
Clean up some warnings in clang
Fix parameters used in wrong order